### PR TITLE
Update faraday version requirement

### DIFF
--- a/lib/ytel_api/http/faraday_client.rb
+++ b/lib/ytel_api/http/faraday_client.rb
@@ -13,13 +13,13 @@ module YtelApi
         faraday.request :multipart
         faraday.request :url_encoded
         faraday.ssl[:ca_file] = Certifi.where
-        faraday.adapter Faraday.default_adapter
         faraday.options[:params_encoder] = Faraday::FlatParamsEncoder
         faraday.options[:open_timeout] = timeout if timeout
         faraday.request :retry, max: max_retries, interval: if max_retries &&
                                                                retry_interval
                                                               retry_interval
                                                             end
+        faraday.adapter Faraday.default_adapter
       end
     end
 

--- a/ytel_api.gemspec
+++ b/ytel_api.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://apimatic.io'
   s.license = 'MIT'
   s.add_dependency('logging', '~> 2.0')
-  s.add_dependency('faraday', '~> 0.15.3')
+  s.add_dependency('faraday', '~> 0.9')
   s.add_dependency('certifi', '~> 2016.9', '>= 2016.09.26')
   s.add_dependency('faraday-http-cache', '~> 1.2', '>= 1.2.2')
   s.required_ruby_version = '~> 2.0'


### PR DESCRIPTION
Not sure this change is suitable for you, but we have a situation when the adding YTEL gem into teh rails app generate bunch of gems versions conflicts, because of faraday version.